### PR TITLE
Utiliza o restore --staged como comando para desfazer alterações e corrige erro de tipografia

### DIFF
--- a/ebook/4.-ajuste-de-mudancas-locais-no-git/4.1-desfazendo-alteracoes-localmente/4.1.1-desfazendo-alteracoes-antes-do-commit.md
+++ b/ebook/4.-ajuste-de-mudancas-locais-no-git/4.1-desfazendo-alteracoes-localmente/4.1.1-desfazendo-alteracoes-antes-do-commit.md
@@ -17,7 +17,7 @@ Isso reverterá o arquivo para o último estado salvo no repositório.
 
 Se você já adicionou o arquivo ao staging com <mark style="color:orange;">git</mark> <mark style="color:purple;">add</mark>, mas deseja remover as mudanças antes do commit, use:
 
-> <mark style="color:purple;">git</mark> <mark style="color:orange;">reset</mark> <mark style="color:green;">HEAD nome-do-arquivo</mark>
+> <mark style="color:purple;">git</mark> <mark style="color:orange;">restore</mark> <mark style="color:green;">--staged nome-do-arquivo</mark>
 
 Isso removerá o arquivo do staging, mas manterá as mudanças no diretório de trabalho.  O comando apenas "desfaz o git add".
 
@@ -34,7 +34,8 @@ Se você já tem alguma experiência com o Git, pode estar se perguntando sobre 
 
 Com o tempo, à medida que o Git evoluía e novas funcionalidades eram adicionadas, o <mark style="color:purple;">git</mark> <mark style="color:orange;">checkout</mark> passou a acumular muitas responsabilidades. Essa sobrecarga de funções gerou certa confusão, especialmente para iniciantes, pois o mesmo comando era usado para realizar operações bem diferentes, como alternar entre branches e restaurar arquivos de versões anteriores.
 
-Para resolver essa confusão e tornar o processo de alternância de branches mais claro, o comando <mark style="color:purple;">git</mark> <mark style="color:orange;">switch</mark> foi introduzido na versão 2.23 do Git, lançada em agosto de 2019. O objetivo principal foi separar as responsabilidades: o <mark style="color:purple;">git</mark> <mark style="color:orange;">switch</mark> foi criado para simplificar a troca de branches, enquanto a restauração de arquivos foi transferida para o comando <mark style="color:purple;">git</mark> <mark style="color:orange;">restore</mark>. Dessa forma, o <mark style="color:purple;">git</mark> <mark style="color:orange;">restora</mark> foca exclusivamente na restauração de arquivos, oferecendo uma experiência mais intuitiva e menos propensa a erros, especialmente para novas pessoas usuárias.
+
+Para resolver essa confusão e tornar o processo de alternância de branches mais claro, o comando <mark style="color:purple;">git</mark> <mark style="color:orange;">switch</mark> foi introduzido na versão 2.23 do Git, lançada em agosto de 2019. O objetivo principal foi separar as responsabilidades: o <mark style="color:purple;">git</mark> <mark style="color:orange;">switch</mark> foi criado para simplificar a troca de branches, enquanto a restauração de arquivos foi transferida para o comando <mark style="color:purple;">git</mark> <mark style="color:orange;">restore</mark>. Dessa forma, o <mark style="color:purple;">git</mark> <mark style="color:orange;">restore</mark> foca exclusivamente na restauração de arquivos, oferecendo uma experiência mais intuitiva e menos propensa a erros, especialmente para novas pessoas usuárias.
 
 Se você ainda estiver usando o <mark style="color:purple;">git</mark> <mark style="color:orange;">checkout</mark> para restauração de arquivos, o <mark style="color:purple;">git</mark> <mark style="color:orange;">restore</mark> é a opção mais moderna e recomendada para essa tarefa.
 {% endhint %}


### PR DESCRIPTION


Valendo da ideia de ser um guia mais moderno e que usa as boas práticas, não faz muito sentido se debruçar no git reset que já é mais chatinho